### PR TITLE
Fix authors list in fmcs.asd

### DIFF
--- a/fmcs.asd
+++ b/fmcs.asd
@@ -8,12 +8,12 @@
 
 (defsystem fmcs
   :description "Flavors Meta-Class System (FMCS) for Demonic Metaprogramming in Common Lisp, an alternative to CLOS+MOP, restored from the CMU AI Repository."
-  :author '("\"the Phoeron\" Colin J.E. Lupton <thephoeron@protonmail.com>"
-            "Jürgen Walther <juergen.walther@gmd.de>"
-            "Pierre Cointe"
-            "Thomas Christaller"
-            "Harry Bretthauer"
-            "Jürgen Kopp")
+  :author ("\"the Phoeron\" Colin J.E. Lupton <thephoeron@protonmail.com>"
+           "Jürgen Walther <juergen.walther@gmd.de>"
+           "Pierre Cointe"
+           "Thomas Christaller"
+           "Harry Bretthauer"
+           "Jürgen Kopp")
   :maintainer "\"the Phoeron\" Colin J.E. Lupton <thephoeron@protonmail.com>"
   :mailto "thephoeron@protonmail.com"
   :homepage "https://thephoeron.github.io/fmcs/"


### PR DESCRIPTION
Lists should not be escaped inside defsystem. Otherwise author will be `(QUOTE ("Foo" "Bar"))`.

This broke distribution building inside Ultralisp :(